### PR TITLE
Update JupyterLite packages

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - empack
 
   - pip:
-    - jupyterlite
-    - jupyterlite-sphinx
-    - jupyterlite-xeus-python
+    - jupyterlite-core >= 0.1.0b19
+    - jupyterlite-sphinx >= 0.8.0
+    - jupyterlite-xeus-python >= 0.7.0
     - jupyterlab-night

--- a/docs/jupyter-lite.json
+++ b/docs/jupyter-lite.json
@@ -2,8 +2,7 @@
     "jupyter-lite-schema-version": 0,
     "jupyter-config-data": {
         "disabledExtensions": [
-          "@jupyterlite/javascript-kernel-extension",
-          "@jupyterlite/pyolite-kernel-extension"
+          "@jupyterlite/javascript-kernel-extension"
         ]
       }
   }


### PR DESCRIPTION
Update to the latest packages and depend on `jupyterlite-core` to avoid bringing the Pyodide kernel by default.